### PR TITLE
Add better check for custom element constructor,

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 sudo: required
 dist: trusty
 before_script:
-- npm install -g web-component-tester
+- npm install web-component-tester
 - npm install bower
 - export PATH=$PWD/node_modules/.bin:$PATH
 - bower install

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="http://juicy.github.io/github-markdown-css/github-markdown.css">
 
     <!-- Imports polyfill -->
-    <script src="../webcomponentsjs/webcomponents.min.js"></script>
+    <script src="../webcomponentsjs/webcomponents-lite.js"></script>
 
     <!-- Imports custom element -->
     <link rel="import" href="juicy-element.html">

--- a/test/spec.html
+++ b/test/spec.html
@@ -27,7 +27,6 @@
         });
 
         it('should be upgraded element', function() {
-            expect(juicyElement).to.be.an.instanceOf(HTMLElement);
             expect(customElements.get('juicy-element')).to.be.defined;
             expect(juicyElement).to.be.an.instanceOf(customElements.get('juicy-element'));
         });

--- a/test/spec.html
+++ b/test/spec.html
@@ -28,7 +28,8 @@
 
         it('should be upgraded element', function() {
             expect(juicyElement).to.be.an.instanceOf(HTMLElement);
-            expect(juicyElement).to.be.not.an.instanceOf(HTMLUnknownElement);
+            expect(customElements.get('juicy-element')).to.be.defined;
+            expect(juicyElement).to.be.an.instanceOf(customElements.get('juicy-element'));
         });
     });
 </script>


### PR DESCRIPTION
to run without an error

Install WCT without `-g`

https://github.com/Juicy/juicy-jsoneditor/pull/24#discussion_r190212220